### PR TITLE
chore(ci): automatically lock issues & prs 4 weeks after closed

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2023 Jonas Tobias Hopusch <git@jotoho.de>
+# SPDX-License-Identifier: CC0-1.0
+#
+# This configuration is based on it's ancestor in https://github.com/jotoho/SchiffeVersenken
+
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    name: Lock Threads job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5.0.1
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: '28'
+          exclude-issue-created-before: ''
+          exclude-issue-created-after: ''
+          exclude-issue-created-between: ''
+          exclude-issue-closed-before: ''
+          exclude-issue-closed-after: ''
+          exclude-issue-closed-between: ''
+          include-any-issue-labels: ''
+          include-all-issue-labels: ''
+          exclude-any-issue-labels: ''
+          add-issue-labels: ''
+          remove-issue-labels: ''
+          issue-comment: ''
+          issue-lock-reason: 'resolved'
+          pr-inactive-days: '28'
+          exclude-pr-created-before: ''
+          exclude-pr-created-after: ''
+          exclude-pr-created-between: ''
+          exclude-pr-closed-before: ''
+          exclude-pr-closed-after: ''
+          exclude-pr-closed-between: ''
+          include-any-pr-labels: ''
+          include-all-pr-labels: ''
+          exclude-any-pr-labels: ''
+          add-pr-labels: ''
+          remove-pr-labels: ''
+          pr-comment: ''
+          pr-lock-reason: 'resolved'
+          process-only: ''
+          log-output: false


### PR DESCRIPTION
I've copied this config from one of my other projects.
It should help ensure that threads aren't necro'd or otherwise misused
after it has been resolved for at least four weeks.

If a thread needs to revived after that, a collaborator can still
manually unlock or simply use their privileges to bypass the lock.

Signed-off-by: Jonas Tobias Hopusch <git@jotoho.de>
