### PR TITLE
feat: improvements to destructive account management operations

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -23,7 +23,7 @@
             <button id="buttonChangePassword">Passwort ändern</button>
           </li>
           <li>
-            <button id="buttonDeleteAccount">Konto löschen</button>
+            <button id="buttonDeleteAccount">Konto sperren</button>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
These changes aim to make account deletion simpler to understand
by reusing leave-household code. It also asks the user to confirm
when leaving households or locking their own account, due to risk of
data loss.
Several bugs that could cause data to be left behind have been remediated.

Signed-off-by: Jonas Tobias Hopusch <git@jotoho.de>
