### PR TITLE
Allow minor non-application changes without full team review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2025 Jonas Tobias Hopusch <git@jotoho.de>
 
-* @jotoho @TimBeckmann
+* @jotoho
+
+/*.html @jotoho @TimBeckmann
+src/* @jotoho @TimBeckmann


### PR DESCRIPTION
Repository management chores and non-breaking dependency updates probably
shouldn't need a full team review.

Approval of @TimBeckmann required.
