### PR TITLE
feat: implement OpenID Connect login via id.jotoho.de

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
 
 <html lang="de">
   <head>
-    <load src="partials/meta.html" />
+    <load src="/partials/meta.html" />
     <title>Einkaufsapp</title>
     <script type="module" src="/src/index.ts"></script>
     <link href="src/index.css" rel="stylesheet" type="text/css" />
   </head>
-  <body>
+  <body id="pageMain">
     <load
       src="/partials/standardheader.html"
       pageTitle="Willkommen zur Einkaufslistenverwaltung!"

--- a/login.html
+++ b/login.html
@@ -28,6 +28,8 @@
             </div>
         </form>
         <hr />
+        <button id="buttonSSOLogin">Login mit Keycloak SSO</button>
+        <hr />
         <p>
             Haben Sie noch kein Konto? Dann können Sie sich <a href="/registration.html">hier registrieren.</a>
         </p>

--- a/oidc/failure.html
+++ b/oidc/failure.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="de">
+  <!--
+        SPDX-License-Identifier: AGPL-3.0-only
+        SPDX-FileCopyrightText: 2025 Jonas Tobias Hopusch <git@jotoho.de>
+  -->
+  <head>
+    <load src="/partials/meta.html" />
+    <title>SSO Anmeldung erfolgreich | Einkaufshelfer</title>
+    <meta http-equiv="refresh" content="5; /login.html" />
+  </head>
+  <body>
+    <load src="/partials/standardheader.html" pageTitle="SSO Erfolgreich" />
+    <main>
+      <p>
+        Ihre SSO Anmeldung ist fehlgeschlagen. Sie werden bald zur lokalen
+        Anmeldung zurückgeleitet.
+      </p>
+    </main>
+  </body>
+</html>

--- a/oidc/success.html
+++ b/oidc/success.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="de">
+  <!--
+        SPDX-License-Identifier: AGPL-3.0-only
+        SPDX-FileCopyrightText: 2025 Jonas Tobias Hopusch <git@jotoho.de>
+    -->
+  <head>
+    <load src="/partials/meta.html" />
+    <title>SSO Anmeldung erfolgreich | Einkaufshelfer</title>
+    <script type="module" src="success.ts"></script>
+  </head>
+  <body>
+    <load src="/partials/standardheader.html" pageTitle="SSO Erfolgreich" />
+    <main>
+      <p>
+        Ihre Anmeldung war erfolgreich. Warten Sie bitte, während wir die
+        Anmeldung intern verarbeiten.
+        <br />
+        Sie werden bald weitergeleitet.
+      </p>
+    </main>
+  </body>
+</html>

--- a/oidc/success.ts
+++ b/oidc/success.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 Jonas Tobias Hopusch <git@jotoho.de>
+
+import { CONFIG } from "../src/config.ts";
+import { showToast } from "../src/notifications.ts";
+import { Client, Account, Models } from "appwrite";
+
+const requestClient = new Client()
+  .setEndpoint(CONFIG.BACKEND_ENDPOINT)
+  .setProject(CONFIG.PROJECT_ID);
+const accountAPI = new Account(requestClient);
+
+accountAPI.getSession("current").then(
+  (session: Models.Session) => {
+    if (session.provider === "oidc") {
+      window.location.href = "/uebersicht.html";
+    } else {
+      showToast(
+        `Unerwartete Sitzungsdaten.
+        Sie wurden durch einen anderen Mechanismus angemeldet und werden bald weitergeleitet.`,
+      );
+      console.error("Unexpected session state", session);
+      setTimeout(() => (window.location.href = "/uebersicht.html"), 5_000);
+    }
+  },
+  (reason: any) => {
+    showToast(
+      "Login unerwartet fehlgeschlagen. Sie werden zur lokalen Anmeldung zurückgeschickt.",
+    );
+    console.error("Login was unsuccessful - no current session.", reason);
+    setTimeout(() => (window.location.href = "/login.html"), 5_000);
+  },
+);

--- a/partials/standardheader.html
+++ b/partials/standardheader.html
@@ -1,3 +1,8 @@
+<noscript>
+  Diese Webanwendung erwartet, dass unser JavaScript uneingeschränkt ausgeführt werden kann
+  und dass Netzwerkanfragen an unser Backend gestattet sind.
+  Falls nicht, wird diese Anwendung nicht funktionieren!
+</noscript>
 <header id="pageHeader" class="standardheader">
   <!--
     SPDX-License-Identifier: AGPL-3.0-only

--- a/src/global.css
+++ b/src/global.css
@@ -85,6 +85,15 @@ h6 {
   padding: 1em;
 }
 
+noscript:has(+ header.standardheader) {
+  display: block;
+  width: 100%;
+  text-align: center;
+  color: rgb(50% 0% 0% / 100%);
+  border: 1px solid rgb(50% 0% 0% / 100%);
+  font-weight: bold;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     scrollbar-color: black transparent;

--- a/src/header.ts
+++ b/src/header.ts
@@ -66,6 +66,15 @@ const userLoggedIn = async (user: Models.User<Models.Preferences>) => {
   if (homeLink) {
     homeLink.href = "/uebersicht.html";
   }
+  const session = await accountAPI.getSession("current");
+  if (
+    session.provider === "oidc" &&
+    session?.providerAccessTokenExpiry &&
+    new Date(session.providerAccessTokenExpiry).getTime() <
+      Date.now() + 1000 * 60 * 30
+  ) {
+    accountAPI.updateSession("current");
+  }
 };
 
 const userNotLoggedIn = async (_: any) => {

--- a/src/login.css
+++ b/src/login.css
@@ -36,3 +36,9 @@ form {
 #error {
     text-align: center;
 }
+
+button#buttonSSOLogin {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // SPDX-FileCopyrightText: 2025 Tim Beckmann <beckmann.tim@fh-swf.de>
 
-import { Client, Account } from "appwrite";
+import { Client, Account, OAuthProvider } from "appwrite";
 import { CONFIG } from './config.ts';
 
 const client: Client = new Client();
@@ -16,6 +16,7 @@ const email = <HTMLInputElement>document.getElementById("email");
 const password = <HTMLInputElement>document.getElementById("password");
 const errorField = <HTMLDivElement>document.getElementById("error");
 const loginButton = <HTMLButtonElement>document.getElementById("loginButton");
+const ssoLoginButton = document.querySelector<HTMLButtonElement>("button#buttonSSOLogin");
 
 isUserLoggedIn().then((isLoggedIn) => {
     if (!isLoggedIn) {
@@ -25,6 +26,9 @@ isUserLoggedIn().then((isLoggedIn) => {
     email.disabled = true;
     password.disabled = true;
     loginButton.disabled = true;
+    if (ssoLoginButton) {
+        ssoLoginButton.disabled = true;
+    }
 
     errorField.innerHTML = `
         <p>Sie sind bereits angemeldet!<br />
@@ -68,4 +72,15 @@ async function isUserLoggedIn(): Promise<boolean> {
         return false;
     }
     return true;
+}
+
+if (ssoLoginButton) {
+    ssoLoginButton.addEventListener("click", async (event) => {
+        event.preventDefault();
+        await account.createOAuth2Session(
+            OAuthProvider.Oidc,
+            document.location.origin + "/oidc/success.html",
+            document.location.origin + "/oidc/failure.html"
+        );
+    }, { once: true });
 }

--- a/uebersicht.html
+++ b/uebersicht.html
@@ -5,7 +5,7 @@
 -->
 <html lang="de">
   <head>
-    <load src="partials/meta.html" />
+    <load src="/partials/meta.html" />
     <title>Ihre Einkaufslisten</title>
     <script type="module" src="src/dashboard.ts"></script>
     <link href="src/dashboard.css" type="text/css" rel="stylesheet" />

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,8 @@ export default defineConfig({
 				registration: resolve(__dirname, '/registration.html'),
 				settings: resolve(__dirname, '/settings.html'),
 				liste: resolve(__dirname, '/liste.html'),
+				oidc_success: resolve(__dirname, '/oidc/success.html'),
+				oidc_failure: resolve(__dirname, '/oidc/failure.html'),
 			},
 		},
 		target: 'es2024',


### PR DESCRIPTION
Using this, users registered on my personal Keycloak instance will be
able to reuse their credentials or use its WebAuthn support.

The Client configuration is set up in Appwrite, so others reusing our code would set their own
OIDC config with another identity provider.

Closes: https://github.com/jotoho/Einkaufshelfer/issues/40
