### PR TITLE
chore: remove explicit reviewer naming in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     directory: "/"
     assignees:
       - "jotoho"
-    reviewers:
-      - "jotoho"
     groups:
       compatible:
         update-types:
@@ -22,8 +20,6 @@ updates:
     directory: "/"
     assignees:
       - "jotoho"
-    reviewers:
-      - "jotoho"
     groups:
       compatible:
         update-types:
@@ -34,8 +30,6 @@ updates:
       interval: "weekly"
     directory: "/functions/invite-to-team/"
     assignees:
-      - "jotoho"
-    reviewers:
       - "jotoho"
     groups:
       compatible:


### PR DESCRIPTION
GitHub has announced that they will be removing support for this
feature from dependabot, instead recommending to rely on CODEOWNERS.

See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/